### PR TITLE
Remove lang to index.html template

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">


### PR DESCRIPTION
Since the lang is set by default in the Page component, having the lang set in the index.html template won't work because of the replace function in the loader: 
`data.replace('<html>', <html ${html}>);` => will never work because the `index.html` `<html>` element = `<html lang="en">`