### PR TITLE
Fixes flash that accurs when hydrating the app

### DIFF
--- a/server/loader.js
+++ b/server/loader.js
@@ -34,9 +34,8 @@ export default (req, res) => {
     data = data.replace('</head>', `${meta}</head>`);
     data = data.replace(
       '<div id="root"></div>',
-      `<div id="root">${body}</div><script>window.__PRELOADED_STATE__ = ${state}</script>`
+      `<div id="root">${body}</div><script>window.__PRELOADED_STATE__ = ${state}</script>${scripts.join('')}`
     );
-    data = data.replace('</body>', scripts.join('') + '</body>');
 
     return data;
   };

--- a/src/app/routes/index.js
+++ b/src/app/routes/index.js
@@ -9,37 +9,43 @@ import NotFound from './not-found';
 const Homepage = Loadable({
   loader: () => import(/* webpackChunkName: "homepage" */ './homepage'),
   loading: () => null,
-  modules: ['homepage']
+  modules: ['homepage'],
+  webpack: () => [require.resolveWeak('./homepage')]
 });
 
 const About = Loadable({
   loader: () => import(/* webpackChunkName: "about" */ './about'),
   loading: () => null,
-  modules: ['about']
+  modules: ['about'],
+  webpack: () => [require.resolveWeak('./about')]
 });
 
 const Dashboard = Loadable({
   loader: () => import(/* webpackChunkName: "dashboard" */ './dashboard'),
   loading: () => null,
-  modules: ['dashboard']
+  modules: ['dashboard'],
+  webpack: () => [require.resolveWeak('./dashboard')]
 });
 
 const Login = Loadable({
   loader: () => import(/* webpackChunkName: "login" */ './login'),
   loading: () => null,
-  modules: ['login']
+  modules: ['login'],
+  webpack: () => [require.resolveWeak('./login')]
 });
 
 const Logout = Loadable({
   loader: () => import(/* webpackChunkName: "logout" */ './logout'),
   loading: () => null,
-  modules: ['logout']
+  modules: ['logout'],
+  webpack: () => [require.resolveWeak('./logout')]
 });
 
 const Profile = Loadable({
   loader: () => import(/* webpackChunkName: "profile" */ './profile'),
   loading: () => null,
-  modules: ['profile']
+  modules: ['profile'],
+  webpack: () => [require.resolveWeak('./profile')]
 });
 
 export default () => (


### PR DESCRIPTION
React was never able to find the modules required to fully render all components when calling `hydrate`. Turns out the issue was 2-folded. CRA doesn't allow access to the webpack config, so we have to manually add the `webpack` field when defining our `Loadable`'s.

However, after doing this the app still did flash. Turns out we insert the modules into the HTML after our main app, causing `Loadable` to not find our modules immediately and borking the `hydrate` call.

This pull request should fix all of that and allow for seamless hydration of the app.